### PR TITLE
Feat/global document search

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -34,14 +34,17 @@ class Settings(BaseSettings):
     # ============ RAG - Embeddings ============
     EMBEDDING_MODEL: str = "BAAI/bge-small-en-v1.5"
     EMBEDDING_DIM: int = 384
-    EMBEDDING_DEVICE: str = "cpu"
+    EMBEDDING_DEVICE: str = "cuda"
     
     # ============ RAG - Retrieval ============
     RAG_TOP_K: int = 3
     RAG_SCORE_THRESHOLD: float = 0.7
-    RAG_CHUNK_SIZE: int = 512
+    RAG_CHUNK_SIZE: int = 1024
     RAG_CHUNK_OVERLAP: int = 50
-    RAG_CHUNK_THRESHOLD: float = 0.7
+    RAG_CHUNK_THRESHOLD: float = 0.5
+    # Search uses a lower threshold than RAG injection — browsing is exploratory
+    SEARCH_SCORE_THRESHOLD: float = 0.45
+    SEARCH_TOP_K: int = 8
     
     # ============ RAG - Directories ============
     RAG_DATA_DIR: str = "rag_data"

--- a/backend/app/routes/rag.py
+++ b/backend/app/routes/rag.py
@@ -14,12 +14,15 @@ from sqlalchemy.orm import Session
 from app.db.session import get_db
 from app.models.user import User
 from app.models.rag_document import RAGDocument
+from app.services.rag.retriever import get_retriever
 from app.schemas.rag import (
     UploadResponse,
     DocumentResponse,
     DocumentListResponse,
     TopicEnum,
-    DocumentStatus
+    DocumentStatus,
+    SearchResultItem,   
+    SearchResponse,
 )
 from app.core.deps import get_current_user
 from app.core.config import settings
@@ -290,3 +293,50 @@ async def delete_document(
     logger.info(f"   ✅ Deleted from database")
     
     return {"message": "Document deleted successfully", "document_id": document_id}
+
+
+@router.get("/search", response_model=SearchResponse)
+async def search_documents(
+    q: str = Query(..., min_length=1, max_length=500, description="Search query"),
+    top_k: int = Query(default=None, ge=1, le=50, description="Number of results"),
+    topic: Optional[TopicEnum] = Query(default=None, description="Filter by topic"),
+    score_threshold: Optional[float] = Query(default=None, ge=0.0, le=1.0),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Semantic search across the user's uploaded documents.
+
+    Unlike the RAG pipeline, this endpoint:
+    - Uses a lower score threshold (exploratory browsing, not LLM injection)
+    - Returns raw chunks with metadata (no LLM involved)
+    - Returns more results (SEARCH_TOP_K vs RAG_TOP_K)
+    """
+    logger.info(f"🔍 Search request from user {current_user.id}: '{q[:60]}'")
+
+    retriever = get_retriever()
+
+    results = retriever.retrieve(
+        query=q,
+        user_id=current_user.id,
+        top_k=top_k or settings.SEARCH_TOP_K,
+        score_threshold=score_threshold or settings.SEARCH_SCORE_THRESHOLD,
+        topic=topic.value if topic else None,
+        include_public=True,
+    )
+
+    items = [
+        SearchResultItem(
+            chunk_text=r["chunk_text"],
+            score=r["score"],
+            document_id=r["document_id"],
+            title=r["title"],
+            chunk_type=r.get("chunk_type", "prose"),
+            page_numbers=r.get("page_numbers", []),
+            chunk_index=r.get("chunk_index", 0),
+        )
+        for r in results
+    ]
+
+    logger.info(f"✅ Search returned {len(items)} results")
+
+    return SearchResponse(query=q, results=items, total=len(items))

--- a/backend/app/schemas/rag.py
+++ b/backend/app/schemas/rag.py
@@ -90,3 +90,21 @@ class DocumentUploadRequest(BaseModel):
         if v and len(v) > 200:
             raise ValueError('Title must be less than 200 characters')
         return v
+    
+
+class SearchResultItem(BaseModel):
+    """A single chunk result from document search."""
+    chunk_text: str
+    score: float
+    document_id: int
+    title: str
+    chunk_type: str = "prose"          # 'prose' | 'code' | 'table'
+    page_numbers: List[int] = []
+    chunk_index: int = 0
+
+
+class SearchResponse(BaseModel):
+    """Response from the document search endpoint."""
+    query: str
+    results: List[SearchResultItem]
+    total: int

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,16 +1,41 @@
+import { useEffect } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { useAuth } from './context/useAuth';
+import { useSearch } from './context/useSearch';
 import Login from './pages/Login';
 import Register from './pages/Register';
 import Chat from './pages/Chat';
 import DocumentLibrary from './pages/DocumentLibrary';
 import ProtectedRoute from './components/ProtectedRoute';
+import SearchModal from './components/SearchModal';
+
+// Cmd+K / Ctrl+K listener — lives here so it's registered once for the whole app
+function GlobalSearchShortcut() {
+  const { openSearch } = useSearch();
+
+  useEffect(() => {
+    const onKey = (e) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        openSearch();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [openSearch]);
+
+  return null; // purely behavioural, renders nothing
+}
 
 function App() {
   const { isLoggedIn } = useAuth();
 
   return (
     <BrowserRouter>
+      {/* SearchModal needs BrowserRouter (useNavigate) but sits outside Routes */}
+      <GlobalSearchShortcut />
+      <SearchModal />
+
       <Routes>
         <Route
           path="/login"
@@ -28,7 +53,6 @@ function App() {
             </ProtectedRoute>
           }
         />
-        {/* NEW: Library page — same ProtectedRoute children pattern */}
         <Route
           path="/library"
           element={

--- a/frontend/src/components/SearchModal.jsx
+++ b/frontend/src/components/SearchModal.jsx
@@ -1,0 +1,258 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useSearch } from '../context/useSearch';
+import { searchAPI } from '../services/api';
+
+// ── Chunk type badge — mirrors SourceCitations.jsx ────────────────────────────
+const CHUNK_BADGE = {
+  code:  { label: '</> code',  color: '#6366f1' },
+  table: { label: '⊞ table',  color: '#0891b2' },
+  prose: { label: '¶ prose',  color: '#059669' },
+};
+
+function ChunkBadge({ type }) {
+  const badge = CHUNK_BADGE[type] ?? CHUNK_BADGE.prose;
+  return (
+    <span
+      className="text-xs font-mono font-semibold px-2 py-0.5 rounded-full flex-shrink-0"
+      style={{ color: badge.color, background: badge.color + '18' }}
+    >
+      {badge.label}
+    </span>
+  );
+}
+
+// ── Score pill ─────────────────────────────────────────────────────────────────
+function ScorePill({ score }) {
+  const pct = Math.round(score * 100);
+  const color = pct >= 80 ? '#059669' : pct >= 65 ? '#d97706' : '#6b7280';
+  return (
+    <span
+      className="text-xs font-semibold px-2 py-0.5 rounded-full flex-shrink-0"
+      style={{ color, background: color + '18' }}
+    >
+      {pct}%
+    </span>
+  );
+}
+
+// ── Skeleton loader ────────────────────────────────────────────────────────────
+function SkeletonResults() {
+  return (
+    <div className="p-4 space-y-4 animate-pulse">
+      {[1, 2].map(g => (
+        <div key={g}>
+          <div className="h-3 w-32 bg-gray-200 rounded mb-2" />
+          {[1, 2, 3].map(r => (
+            <div key={r} className="mb-2 rounded-xl border border-gray-100 p-3">
+              <div className="flex gap-2 mb-2">
+                <div className="h-4 w-16 bg-gray-200 rounded-full" />
+                <div className="h-4 w-10 bg-gray-200 rounded-full" />
+              </div>
+              <div className="h-3 w-full bg-gray-100 rounded mb-1" />
+              <div className="h-3 w-3/4 bg-gray-100 rounded" />
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Group results by document ─────────────────────────────────────────────────
+function groupByDocument(results) {
+  const map = new Map();
+  for (const r of results) {
+    if (!map.has(r.document_id)) {
+      map.set(r.document_id, { title: r.title, document_id: r.document_id, chunks: [] });
+    }
+    map.get(r.document_id).chunks.push(r);
+  }
+  return Array.from(map.values());
+}
+
+// ── Main modal ─────────────────────────────────────────────────────────────────
+export default function SearchModal() {
+  const { isOpen, closeSearch } = useSearch();
+  const navigate = useNavigate();
+
+  const [query,   setQuery]   = useState('');
+  const [results, setResults] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [searched, setSearched] = useState(false); // true once first search fired
+
+  const inputRef    = useRef(null);
+  const debounceRef = useRef(null);
+
+  // Auto-focus input when modal opens; reset state when it closes
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => inputRef.current?.focus(), 50);
+    } else {
+      setQuery('');
+      setResults([]);
+      setSearched(false);
+    }
+  }, [isOpen]);
+
+  // Escape key closes modal
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') closeSearch(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [closeSearch]);
+
+  // Debounced search
+  const handleQueryChange = useCallback((e) => {
+    const value = e.target.value;
+    setQuery(value);
+
+    clearTimeout(debounceRef.current);
+
+    if (!value.trim()) {
+      setResults([]);
+      setSearched(false);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const res = await searchAPI.search(value.trim());
+        setResults(res.data.results ?? []);
+      } catch (err) {
+        console.error('Search failed:', err);
+        setResults([]);
+      } finally {
+        setLoading(false);
+        setSearched(true);
+      }
+    }, 350);
+  }, []);
+
+  const handleResultClick = useCallback((documentId) => {
+    navigate(`/library?highlight=${documentId}`);
+    closeSearch();
+  }, [navigate, closeSearch]);
+
+  if (!isOpen) return null;
+
+  const groups = groupByDocument(results);
+
+  return (
+    // Backdrop
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center pt-24 px-4"
+      style={{ background: 'rgba(0,0,0,0.45)' }}
+      onMouseDown={(e) => { if (e.target === e.currentTarget) closeSearch(); }}
+    >
+      {/* Panel */}
+      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-2xl flex flex-col overflow-hidden"
+           style={{ maxHeight: '70vh' }}>
+
+        {/* Search input row */}
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-100">
+          <span className="text-gray-400 text-lg">🔍</span>
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={handleQueryChange}
+            placeholder="Search your documents…"
+            className="flex-1 text-sm text-gray-800 placeholder-gray-400 outline-none bg-transparent"
+          />
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <kbd className="hidden sm:inline-flex items-center gap-1 rounded-md border border-gray-200 px-1.5 py-0.5 text-xs text-gray-400">
+              ⌘K
+            </kbd>
+            <button
+              onClick={closeSearch}
+              className="text-xs text-gray-400 hover:text-gray-600 border border-gray-200 rounded-md px-1.5 py-0.5"
+            >
+              ESC
+            </button>
+          </div>
+        </div>
+
+        {/* Results area */}
+        <div className="overflow-y-auto flex-1">
+
+          {/* Loading skeleton */}
+          {loading && <SkeletonResults />}
+
+          {/* Results grouped by doc */}
+          {!loading && groups.length > 0 && (
+            <div className="p-4 space-y-5">
+              {groups.map(group => (
+                <div key={group.document_id}>
+                  {/* Document header */}
+                  <p className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-2 px-1">
+                    📄 {group.title}
+                  </p>
+
+                  <div className="space-y-2">
+                    {group.chunks.map((chunk, idx) => (
+                      <button
+                        key={idx}
+                        onClick={() => handleResultClick(group.document_id)}
+                        className="w-full text-left rounded-xl border border-gray-100 hover:border-blue-200 hover:bg-blue-50 px-3 py-2.5 transition-colors"
+                      >
+                        {/* Meta row */}
+                        <div className="flex items-center gap-2 mb-1.5 flex-wrap">
+                          <ChunkBadge type={chunk.chunk_type} />
+                          {chunk.page_numbers?.length > 0 && (
+                            <span className="text-xs text-gray-400">
+                              p.{chunk.page_numbers.join(', ')}
+                            </span>
+                          )}
+                          <ScorePill score={chunk.score} />
+                        </div>
+
+                        {/* Chunk preview */}
+                        <p className="text-xs text-gray-600 leading-relaxed line-clamp-3">
+                          {chunk.chunk_text}
+                        </p>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Empty — no query */}
+          {!loading && !searched && (
+            <div className="flex flex-col items-center justify-center py-16 text-center px-4">
+              <p className="text-3xl mb-3">🔍</p>
+              <p className="text-sm font-medium text-gray-600">Search across your documents</p>
+              <p className="text-xs text-gray-400 mt-1">
+                Try a concept, keyword, or question from your study material
+              </p>
+            </div>
+          )}
+
+          {/* Empty — searched but no results */}
+          {!loading && searched && results.length === 0 && (
+            <div className="flex flex-col items-center justify-center py-16 text-center px-4">
+              <p className="text-3xl mb-3">📭</p>
+              <p className="text-sm font-medium text-gray-600">No results for "{query}"</p>
+              <p className="text-xs text-gray-400 mt-1">
+                Try a different keyword, or check that your documents are fully indexed
+              </p>
+            </div>
+          )}
+
+        </div>
+
+        {/* Footer */}
+        {!loading && results.length > 0 && (
+          <div className="px-4 py-2 border-t border-gray-100 flex items-center justify-between">
+            <p className="text-xs text-gray-400">{results.length} chunk{results.length !== 1 ? 's' : ''} found</p>
+            <p className="text-xs text-gray-400">Click a result to open in Library</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/context/SearchContext.jsx
+++ b/frontend/src/context/SearchContext.jsx
@@ -1,0 +1,16 @@
+import { createContext, useState, useCallback } from 'react';
+
+export const SearchContext = createContext(null);
+
+export function SearchProvider({ children }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openSearch  = useCallback(() => setIsOpen(true),  []);
+  const closeSearch = useCallback(() => setIsOpen(false), []);
+
+  return (
+    <SearchContext.Provider value={{ isOpen, openSearch, closeSearch }}>
+      {children}
+    </SearchContext.Provider>
+  );
+}

--- a/frontend/src/context/useSearch.js
+++ b/frontend/src/context/useSearch.js
@@ -1,0 +1,8 @@
+import { useContext } from 'react';
+import { SearchContext } from './SearchContext';
+
+export function useSearch() {
+  const ctx = useContext(SearchContext);
+  if (!ctx) throw new Error('useSearch must be used inside <SearchProvider>');
+  return ctx;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -6,8 +6,10 @@ import { AuthProvider } from './context/AuthContext.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <AuthProvider>
-      <App />
-    </AuthProvider>
+    <SearchProvider>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </SearchProvider>
   </StrictMode>,
 )

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
 import { AuthProvider } from './context/AuthContext.jsx'
+import { SearchProvider } from './context/SearchContext.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/frontend/src/pages/Chat.jsx
+++ b/frontend/src/pages/Chat.jsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useAuth } from '../context/useAuth';
 import { conversationsAPI, streamMessage } from '../services/api';
 import MessageBubble from '../components/MessageBubble';
+import { useSearch } from '../context/useSearch';
 
 
 function Chat() {
@@ -23,6 +24,7 @@ function Chat() {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
   const { conversationId: urlConversationId } = useParams();
+  const { openSearch } = useSearch();
 
   // ============ Effects ============
 
@@ -262,6 +264,16 @@ function Chat() {
             📚 My Library
           </button>
         </div>
+        {/* Search — NEW */}
+<button
+  onClick={openSearch}
+  className="w-full bg-gray-700 hover:bg-gray-600 text-gray-200 rounded-lg py-2 px-4 text-sm font-medium transition-colors text-left flex items-center justify-between"
+>
+  <span>🔍 Search Docs</span>
+  <kbd className="hidden sm:inline-flex text-xs text-gray-400 border border-gray-600 rounded px-1">
+    ⌘K
+  </kbd>
+</button>
 
         {/* Conversations List */}
         <div className="flex-1 overflow-y-auto px-3 space-y-1">

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -234,6 +234,25 @@ export const streamMessage = async (
   }
 };
 
+export const searchAPI = {
+  /**
+   * Semantic search across the user's documents.
+   *
+   * @param {string}  query
+   * @param {Object}  [opts]
+   * @param {number}  [opts.topK]           - max results (default: backend's SEARCH_TOP_K=8)
+   * @param {string}  [opts.topic]          - optional TopicEnum filter
+   * @param {number}  [opts.scoreThreshold] - optional override
+   */
+  search: (query, { topK, topic, scoreThreshold } = {}) => {
+    const params = new URLSearchParams({ q: query });
+    if (topK)           params.append('top_k',           topK);
+    if (topic)          params.append('topic',           topic);
+    if (scoreThreshold) params.append('score_threshold', scoreThreshold);
+    return api.get(`/api/rag/search?${params.toString()}`);
+  },
+};
+
 // ============================================================
 // DOCUMENTS — NEW
 // ============================================================


### PR DESCRIPTION
Closes #1 

Implements semantic search across all user documents via a modal accessible from any page (Cmd+K).

## Changes
- `GET /api/rag/search` endpoint with dedicated `SEARCH_SCORE_THRESHOLD=0.45`
- `SearchContext` + `useSearch` hook at app root
- `SearchModal` with debounced input, grouped results, chunk badges, score %
- `Cmd+k` global shortcut + Chat sidebar trigger"