### PR TITLE
Feat/chunk preview panel

### DIFF
--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -121,7 +121,8 @@ async def chat_stream(
                                 "document_id": src['document_id'],
                                 "score": src['score'],
                                 "page_numbers": src.get('page_numbers', []),
-                                "chunk_type": src.get('chunk_type', 'prose')
+                                "chunk_type": src.get('chunk_type', 'prose'),
+                                "chunk_index": src.get('chunk_index', None)
                             }
                             for src in rag_result['sources']
                         ]

--- a/backend/app/routes/rag.py
+++ b/backend/app/routes/rag.py
@@ -23,6 +23,8 @@ from app.schemas.rag import (
     DocumentStatus,
     SearchResultItem,   
     SearchResponse,
+    ChunkPreviewItem,       
+    ChunkPreviewResponse,   
 )
 from app.core.deps import get_current_user
 from app.core.config import settings
@@ -340,3 +342,25 @@ async def search_documents(
     logger.info(f"✅ Search returned {len(items)} results")
 
     return SearchResponse(query=q, results=items, total=len(items))
+
+
+@router.get("/chunks", response_model=ChunkPreviewResponse)
+async def get_chunk_preview(
+    document_id: int = Query(..., description="Document ID"),
+    chunk_index: int = Query(..., ge=0, description="Target chunk index"),
+    window: int = Query(default=2, ge=0, le=5, description="Neighbors on each side"),
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Fetch a chunk and its neighbors for the preview panel.
+
+    Returns the target chunk plus `window` chunks before and after it,
+    ordered by chunk_index. The target chunk is flagged with is_target=True.
+    """
+    retriever = get_retriever()
+    result = retriever.retrieve_chunk_preview(document_id, chunk_index, window, current_user.id)
+
+    if not result:
+        raise HTTPException(status_code=404, detail="Chunk not found")
+
+    return ChunkPreviewResponse(**result)

--- a/backend/app/schemas/rag.py
+++ b/backend/app/schemas/rag.py
@@ -108,3 +108,19 @@ class SearchResponse(BaseModel):
     query: str
     results: List[SearchResultItem]
     total: int
+
+
+class ChunkPreviewItem(BaseModel):
+    """A single chunk in the preview panel (target or neighbor)."""
+    chunk_text: str
+    chunk_index: int
+    chunk_type: str = "prose"
+    page_numbers: List[int] = []
+    is_target: bool = False      
+
+
+class ChunkPreviewResponse(BaseModel):
+    """Response from the chunk preview endpoint."""
+    document_id: int
+    title: str
+    chunks: List[ChunkPreviewItem]  

--- a/backend/app/services/rag/retriever.py
+++ b/backend/app/services/rag/retriever.py
@@ -221,6 +221,97 @@ class Retriever:
         
         return formatted
     
+    def retrieve_chunk_preview(
+        self,
+        document_id: int,
+        chunk_index: int,
+        user_id: int,
+        window: int = 2
+    ) -> Optional[Dict]:
+        """
+        Fetch a target chunk and its neighbors for the preview panel.
+
+        Args:
+            document_id: Document to fetch from
+            chunk_index: Index of the target chunk
+            window: Number of neighbors on each side (default 2)
+
+        Returns:
+            Dict with document title and ordered list of chunks,
+            or None if the target chunk is not found.
+        """
+        from qdrant_client.models import Range
+
+        min_idx = max(0, chunk_index - window)
+        max_idx = chunk_index + window
+
+        logger.info(
+            f"Fetching chunk preview: doc={document_id} "
+            f"idx={chunk_index} window={window}"
+        )
+
+        try:
+            results, _ = self.client.scroll(
+            collection_name=self.collection_name,
+            scroll_filter=Filter(
+                must=[
+                    FieldCondition(
+                        key="document_id",
+                        match=MatchValue(value=document_id)
+                    ),
+                    FieldCondition(
+                        key="chunk_index",
+                        range=Range(gte=min_idx, lte=max_idx)
+                    ),
+                ],
+                #should=[
+                #    FieldCondition(
+                #        key="user_id",
+                #        match=MatchValue(value=user_id)
+                #    ),
+                #    FieldCondition(
+                #        key="is_public",
+                #        match=MatchValue(value=True)
+                #    ),
+                #]
+            ),
+            limit=window * 2 + 1,
+            with_payload=True,
+            with_vectors=False,
+            )
+
+            if not results:
+                logger.warning(f"⚠️  No chunks found for doc={document_id} idx={chunk_index}")
+                return None
+
+            title = results[0].payload.get("title", "Unknown")
+
+            chunks = sorted(
+                [
+                    {
+                        "chunk_text": p.payload.get("chunk_text", ""),
+                        "chunk_index": p.payload.get("chunk_index", 0),
+                        "chunk_type": p.payload.get("chunk_type", "prose"),
+                        "page_numbers": p.payload.get("page_numbers", []),
+                        "is_target": p.payload.get("chunk_index") == chunk_index,
+                    }
+                    for p in results
+                ],
+                key=lambda c: c["chunk_index"],
+            )
+
+            logger.info(f"✅ Retrieved {len(chunks)} chunks for preview")
+
+            return {
+                "document_id": document_id,
+                "title": title,
+                "chunks": chunks,
+            }
+
+        except Exception as e:
+            logger.error(f"❌ Chunk preview retrieval failed: {e}")
+            raise
+    
     def retrieve_by_document(
         self,
         document_id: int,

--- a/backend/app/services/rag_service.py
+++ b/backend/app/services/rag_service.py
@@ -265,6 +265,7 @@ class RAGService:
                         "score": r["score"],
                         "page_numbers": r.get("page_numbers", []),
                         "chunk_type": r.get("chunk_type", "prose"),
+                        "chunk_index": r.get("chunk_index", None)
                     }
                     for r in results
                 ]

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import Register from './pages/Register';
 import Chat from './pages/Chat';
 import DocumentLibrary from './pages/DocumentLibrary';
 import ProtectedRoute from './components/ProtectedRoute';
+import ChunkPreviewPanel from './components/ChunkPreviewPanel';
 import SearchModal from './components/SearchModal';
 
 // Cmd+K / Ctrl+K listener — lives here so it's registered once for the whole app
@@ -35,6 +36,7 @@ function App() {
       {/* SearchModal needs BrowserRouter (useNavigate) but sits outside Routes */}
       <GlobalSearchShortcut />
       <SearchModal />
+      <ChunkPreviewPanel />
 
       <Routes>
         <Route

--- a/frontend/src/components/ChunkPreviewPanel.jsx
+++ b/frontend/src/components/ChunkPreviewPanel.jsx
@@ -1,0 +1,231 @@
+import { useEffect, useState } from 'react';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { useChunkPreview } from '../context/useChunkPreview';
+import { chunkPreviewAPI } from '../services/api';
+
+// ── Chunk type badge — same colours as SearchModal / SourceCitations ──────────
+const CHUNK_BADGE = {
+  code:  { label: '</> code',  color: '#6366f1' },
+  table: { label: '⊞ table',  color: '#0891b2' },
+  prose: { label: '¶ prose',  color: '#059669' },
+};
+
+function ChunkBadge({ type }) {
+  const badge = CHUNK_BADGE[type] ?? CHUNK_BADGE.prose;
+  return (
+    <span
+      className="text-xs font-mono font-semibold px-2 py-0.5 rounded-full flex-shrink-0"
+      style={{ color: badge.color, background: badge.color + '18' }}
+    >
+      {badge.label}
+    </span>
+  );
+}
+
+// ── Individual chunk row ───────────────────────────────────────────────────────
+function ChunkRow({ chunk }) {
+  const isTarget = chunk.is_target;
+
+  return (
+    <div
+      className={`rounded-xl px-3 py-3 transition-colors ${
+        isTarget
+          ? 'bg-blue-50 border-l-4 border-blue-500'
+          : 'bg-gray-50 border border-gray-100'
+      }`}
+    >
+      {/* Meta row */}
+      <div className="flex items-center gap-2 mb-2 flex-wrap">
+        {isTarget && (
+          <span className="text-xs font-semibold text-blue-600 bg-blue-100 px-2 py-0.5 rounded-full">
+            → source
+          </span>
+        )}
+        <ChunkBadge type={chunk.chunk_type} />
+        {chunk.page_numbers?.length > 0 && (
+          <span className="text-xs text-gray-400">
+            p.{chunk.page_numbers.join(', ')}
+          </span>
+        )}
+        <span className="text-xs text-gray-300 ml-auto">
+          #{chunk.chunk_index}
+        </span>
+      </div>
+
+      {/* Content */}
+      {chunk.chunk_type === 'code' ? (
+        <SyntaxHighlighter
+          language="java"
+          style={oneDark}
+          customStyle={{
+            margin: 0,
+            borderRadius: '8px',
+            fontSize: '12px',
+            padding: '12px',
+          }}
+        >
+          {chunk.chunk_text}
+        </SyntaxHighlighter>
+      ) : (
+        <p className="text-xs text-gray-700 leading-relaxed whitespace-pre-wrap">
+          {chunk.chunk_text}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ── Loading skeleton ───────────────────────────────────────────────────────────
+function SkeletonPanel() {
+  return (
+    <div className="p-4 space-y-3 animate-pulse">
+      {[1, 2, 3, 4, 5].map(i => (
+        <div key={i} className={`rounded-xl p-3 ${i === 3 ? 'bg-blue-50' : 'bg-gray-50'}`}>
+          <div className="flex gap-2 mb-2">
+            <div className="h-4 w-16 bg-gray-200 rounded-full" />
+            <div className="h-4 w-10 bg-gray-200 rounded-full" />
+          </div>
+          <div className="space-y-1.5">
+            <div className="h-3 w-full bg-gray-200 rounded" />
+            <div className="h-3 w-4/5 bg-gray-200 rounded" />
+            {i === 3 && <div className="h-3 w-3/5 bg-gray-200 rounded" />}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Main panel ─────────────────────────────────────────────────────────────────
+export default function ChunkPreviewPanel() {
+  const { isOpen, preview, closePreview } = useChunkPreview();
+  const [chunks, setChunks]   = useState([]);
+  const [title,  setTitle]    = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error,   setError]   = useState(null);
+
+  // Fetch chunks whenever the preview target changes
+  useEffect(() => {
+    if (!preview) return;
+
+    // Graceful fallback — old messages don't have chunk_index
+    if (preview.chunk_index == null) {
+      setChunks([]);
+      setError('no_index');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    setChunks([]);
+
+    chunkPreviewAPI
+      .getChunks(preview.document_id, preview.chunk_index, 2)
+      .then(res => {
+        setChunks(res.data.chunks ?? []);
+        setTitle(res.data.title ?? preview.title ?? '');
+      })
+      .catch(err => {
+        console.error('Chunk preview failed:', err);
+        setError('fetch_failed');
+      })
+      .finally(() => setLoading(false));
+  }, [preview]);
+
+  // Escape key closes panel
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') closePreview(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [closePreview]);
+
+  return (
+    <>
+      {/* Backdrop — only visible when open */}
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-40"
+          style={{ background: 'rgba(0,0,0,0.25)' }}
+          onClick={closePreview}
+        />
+      )}
+
+      {/* Slide-in panel */}
+      <div
+        className="fixed top-0 right-0 h-full bg-white shadow-2xl z-50 flex flex-col"
+        style={{
+          width: '420px',
+          transform: isOpen ? 'translateX(0)' : 'translateX(100%)',
+          transition: 'transform 0.25s ease-in-out',
+        }}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between px-4 py-3 border-b border-gray-100 flex-shrink-0">
+          <div>
+            <p className="text-sm font-semibold text-gray-800 truncate">
+              📄 {title || preview?.title || 'Document'}
+            </p>
+            <p className="text-xs text-gray-400 mt-0.5">
+              Chunk context · {chunks.length} chunk{chunks.length !== 1 ? 's' : ''}
+            </p>
+          </div>
+          <button
+            onClick={closePreview}
+            className="text-gray-400 hover:text-gray-600 text-lg leading-none ml-4 flex-shrink-0"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto">
+
+          {loading && <SkeletonPanel />}
+
+          {/* No chunk_index — old message fallback */}
+          {!loading && error === 'no_index' && (
+            <div className="flex flex-col items-center justify-center h-full text-center px-6">
+              <p className="text-3xl mb-3">📋</p>
+              <p className="text-sm font-medium text-gray-600">Context unavailable</p>
+              <p className="text-xs text-gray-400 mt-1">
+                This source was saved before chunk preview was supported.
+                Send a new message to get full context.
+              </p>
+            </div>
+          )}
+
+          {/* Fetch failed */}
+          {!loading && error === 'fetch_failed' && (
+            <div className="flex flex-col items-center justify-center h-full text-center px-6">
+              <p className="text-3xl mb-3">⚠️</p>
+              <p className="text-sm font-medium text-gray-600">Failed to load chunks</p>
+              <p className="text-xs text-gray-400 mt-1">
+                Check that your backend is running and the document is still indexed.
+              </p>
+            </div>
+          )}
+
+          {/* Chunks */}
+          {!loading && !error && chunks.length > 0 && (
+            <div className="p-4 space-y-3">
+              {chunks.map((chunk) => (
+                <ChunkRow key={chunk.chunk_index} chunk={chunk} />
+              ))}
+            </div>
+          )}
+
+        </div>
+
+        {/* Footer */}
+        {!loading && !error && chunks.length > 0 && (
+          <div className="px-4 py-2 border-t border-gray-100 flex-shrink-0">
+            <p className="text-xs text-gray-400">
+              Showing ±2 chunks around the source · ESC to close
+            </p>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/SourceCitations.jsx
+++ b/frontend/src/components/SourceCitations.jsx
@@ -7,7 +7,7 @@
 // ============================================================
 
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useChunkPreview } from '../context/useChunkPreview';
 
 // Relevance thresholds → color + label
 const scoreStyle = (score) => {
@@ -25,7 +25,7 @@ const chunkBadge = (chunkType) => {
 
 function SourceCitations({ sources = [], ragUsed = false }) {
   const [expanded, setExpanded] = useState(false);
-  const navigate = useNavigate();
+  const { openPreview } = useChunkPreview();
 
   // No RAG used or no sources → show subtle "general knowledge" tag
   if (!ragUsed || !sources.length) {
@@ -57,17 +57,22 @@ function SourceCitations({ sources = [], ragUsed = false }) {
             const badge = chunkBadge(source.chunk_type);
             return (
               <div
-                key={source.document_id ?? index}
+                key={`${source.document_id}-${source.chunk_index ?? index}`}
                 className="flex items-center justify-between rounded-lg bg-gray-50 border border-gray-200 px-3 py-2"
               >
                 {/* Left: document name + page numbers */}
                 <div className="flex items-center gap-1.5 truncate">
                   <button
-                    onClick={() => navigate(`/library?highlight=${source.document_id}`)}
-                    className="text-xs text-gray-700 hover:text-blue-600 truncate text-left font-medium"
-                  >
-                    📄 {source.title}
-                  </button>
+  onClick={() => openPreview({
+    document_id:  source.document_id,
+    chunk_index:  source.chunk_index ?? null,
+    title:        source.title,
+    chunk_type:   source.chunk_type,
+  })}
+  className="text-xs text-gray-700 hover:text-blue-600 truncate text-left font-medium"
+>
+  📄 {source.title}
+</button>
                   {source.page_numbers?.length > 0 && (
                     <span className="text-xs text-gray-400 flex-shrink-0">
                       p.{source.page_numbers.join(', ')}

--- a/frontend/src/context/ChunkPreviewContext.jsx
+++ b/frontend/src/context/ChunkPreviewContext.jsx
@@ -1,0 +1,25 @@
+import { createContext, useState, useCallback } from 'react';
+
+export const ChunkPreviewContext = createContext(null);
+
+export function ChunkPreviewProvider({ children }) {
+  const [isOpen,  setIsOpen]  = useState(false);
+  const [preview, setPreview] = useState(null);
+  // preview shape: { document_id, chunk_index, title, chunk_type }
+
+  const openPreview = useCallback((data) => {
+    setPreview(data);
+    setIsOpen(true);
+  }, []);
+
+  const closePreview = useCallback(() => {
+    setIsOpen(false);
+    setPreview(null);
+  }, []);
+
+  return (
+    <ChunkPreviewContext.Provider value={{ isOpen, preview, openPreview, closePreview }}>
+      {children}
+    </ChunkPreviewContext.Provider>
+  );
+}

--- a/frontend/src/context/useChunkPreview.js
+++ b/frontend/src/context/useChunkPreview.js
@@ -1,0 +1,8 @@
+import { useContext } from 'react';
+import { ChunkPreviewContext } from './ChunkPreviewContext';
+
+export function useChunkPreview() {
+  const ctx = useContext(ChunkPreviewContext);
+  if (!ctx) throw new Error('useChunkPreview must be used inside <ChunkPreviewProvider>');
+  return ctx;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -8,9 +8,11 @@ import { SearchProvider } from './context/SearchContext.jsx';
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <SearchProvider>
-      <AuthProvider>
-        <App />
-      </AuthProvider>
+      <ChunkPreviewProvider>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </ChunkPreviewProvider>
     </SearchProvider>
   </StrictMode>,
 )

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,6 +4,7 @@ import './index.css'
 import App from './App.jsx'
 import { AuthProvider } from './context/AuthContext.jsx'
 import { SearchProvider } from './context/SearchContext.jsx';
+import { ChunkPreviewProvider } from './context/ChunkPreviewContext.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -108,6 +108,28 @@ export const authAPI = {
 };
 
 // ============================================================
+// CHUNK PREVIEW
+// ============================================================
+
+export const chunkPreviewAPI = {
+  /**
+   * Fetch a target chunk and its neighbors for the preview panel.
+   *
+   * @param {number} documentId
+   * @param {number} chunkIndex
+   * @param {number} [window=2]  - neighbors on each side
+   */
+  getChunks: (documentId, chunkIndex, window = 2) =>
+    api.get('/api/rag/chunks', {
+      params: {
+        document_id: documentId,
+        chunk_index: chunkIndex,
+        window,
+      },
+    }),
+};
+
+// ============================================================
 // CONVERSATIONS — unchanged
 // ============================================================
 export const conversationsAPI = {


### PR DESCRIPTION
Closes #3 

Slide-in drawer showing full chunk context when a source citation is clicked in chat.

## Changes
- retrieve_chunk_preview() on Retriever with user_id privacy enforcement
- GET /api/rag/chunks fetches target chunk + N neighbors via Qdrant scroll
- chunk_index persisted in sources (rag_service + streaming route)
- ChunkPreviewContext + useChunkPreview hook at app root
- ChunkPreviewPanel slide-in drawer with syntax highlighting, skeleton, fallback states
- SourceCitations click triggers preview panel instead of Library navigation
- Fix duplicate key warning using composite document_id-chunk_index key"