### PR TITLE
Feat/indexing performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ api:
 
 # Start Celery worker for background PDF processing
 celery:
-	cd backend && uv run celery -A app.celery_app worker --loglevel=info
+	cd backend && uv run celery -A app.celery_app worker --loglevel=info --concurrency=2
 
 # ============ Frontend ============
 # Start React dev server

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ lint:
 lint-frontend:
 	cd frontend && npm run lint
 
+# Start Celery Beat scheduler for periodic tasks
+celery-beat:
+	cd backend && uv run celery -A app.celery_app beat --loglevel=info
+
 # Run tests
 test:
 	cd backend && uv run pytest

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -12,7 +12,7 @@ celery_app = Celery(
     "codementor",
     broker=settings.CELERY_BROKER_URL,
     backend=settings.CELERY_RESULT_BACKEND,
-    include=['app.tasks.rag_tasks']  # Import task modules
+    include=['app.tasks.rag_tasks', 'app.tasks.cleanup_tasks']  # Import task modules
 )
 
 # Celery configuration
@@ -27,6 +27,12 @@ celery_app.conf.update(
     task_soft_time_limit=25 * 60,  # Soft limit at 25 minutes
     worker_prefetch_multiplier=1,  # Fetch one task at a time
     worker_max_tasks_per_child=50,  # Restart worker after 50 tasks (prevent memory leaks)
+    beat_schedule={
+        'cleanup-expired-uploads': {
+            'task': 'codementor.cleanup-uploads',
+            'schedule': 3600.0,  # every hour
+        },
+    }
 )
 
 # Optional: Configure result expiration

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -10,6 +10,8 @@ class Settings(BaseSettings):
     DEBUG: bool = True
     HOST: str = "0.0.0.0"
     PORT: int = 8000
+
+    EXTRACTION_WORKERS: int = 4  # For parallel PDF page extraction
     
     # ============ Database ============
     DATABASE_URL: str
@@ -35,6 +37,7 @@ class Settings(BaseSettings):
     EMBEDDING_MODEL: str = "BAAI/bge-small-en-v1.5"
     EMBEDDING_DIM: int = 384
     EMBEDDING_DEVICE: str = "cuda"
+    EMBEDDING_BATCH_SIZE: int = 64
     
     # ============ RAG - Retrieval ============
     RAG_TOP_K: int = 3
@@ -63,6 +66,7 @@ class Settings(BaseSettings):
     # ============ RAG - File Upload ============
     UPLOAD_DIR: str = "/tmp/codementor_uploads"
     MAX_UPLOAD_SIZE: int = 52428800  # 50MB
+    UPLOAD_RETENTION_HOURS: int = 24
     
     # ============ Default Superadmin ============
     DEFAULT_SUPERADMIN_EMAIL: Optional[str] = None

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -11,7 +11,7 @@ class Settings(BaseSettings):
     HOST: str = "0.0.0.0"
     PORT: int = 8000
 
-    EXTRACTION_WORKERS: int = 4  # For parallel PDF page extraction
+    EXTRACTION_WORKERS: int = 1  # For parallel PDF page extraction
     
     # ============ Database ============
     DATABASE_URL: str

--- a/backend/app/services/rag/chunker.py
+++ b/backend/app/services/rag/chunker.py
@@ -57,7 +57,8 @@ class Chunker:
                 threshold=self.threshold,
                 chunk_size=self.chunk_size,
                 min_sentences_per_chunk=1,
-                skip_window=self.skip_window
+                skip_window=self.skip_window,
+                device=settings.EMBEDDING_DEVICE
             )
             logger.info(f"✅ SemanticChunker initialized successfully")
             

--- a/backend/app/services/rag/indexer.py
+++ b/backend/app/services/rag/indexer.py
@@ -12,6 +12,7 @@ Pipeline:
 """
 import logging
 import pymupdf  # PyMuPDF (fitz)
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Dict, Optional
@@ -31,6 +32,12 @@ from app.services.rag.embedder import get_embedder
 from app.services.rag.chunker import get_chunker
 
 logger = logging.getLogger(__name__)
+
+
+# Number of threads for parallel page extraction.
+# PyMuPDF releases the GIL during C-level operations, making
+# thread-based parallelism effective for page parsing.
+EXTRACTION_WORKERS = 4
 
 # Monospace font families used for code rendering in PDFs
 MONOSPACE_FONTS = {
@@ -141,6 +148,11 @@ class Indexer:
         """
         Extract typed elements (code, tables, prose) from a PDF.
         
+        Uses ThreadPoolExecutor to parallelize page extraction.
+        Each thread opens its own document handle for thread safety.
+        PyMuPDF releases the GIL during C-level operations, making
+        threads effective for this workload.
+        
         Per page, extraction order:
         1. Tables (via find_tables) — mark regions as claimed
         2. Code blocks (via monospace font detection) — mark regions as claimed
@@ -155,23 +167,52 @@ class Indexer:
         try:
             logger.info(f"📄 Extracting structured elements from: {pdf_path}")
             
+            # Open briefly just to read page count and metadata
             doc = pymupdf.open(pdf_path)
+            total_pages = len(doc)
+            doc.close()
             
             metadata = {
-                "pages_count": len(doc),
+                "pages_count": total_pages,
                 "file_size_bytes": Path(pdf_path).stat().st_size,
             }
             
+            # Split pages into ranges for parallel extraction
+            workers = min(EXTRACTION_WORKERS, total_pages)
+            pages_per_worker = total_pages // workers
+            remainder = total_pages % workers
+            
+            ranges = []
+            start = 0
+            for i in range(workers):
+                # Distribute remainder pages across first N workers
+                end = start + pages_per_worker + (1 if i < remainder else 0)
+                ranges.append((start, end))
+                start = end
+            
+            logger.info(f"   Parallelizing extraction: {workers} workers, {total_pages} pages")
+            
+            # Extract in parallel — each worker opens its own doc handle
             all_elements = []
+            with ThreadPoolExecutor(max_workers=workers) as executor:
+                futures = {
+                    executor.submit(
+                        self._extract_page_range, pdf_path, r[0], r[1]
+                    ): r
+                    for r in ranges
+                }
+                
+                for future in as_completed(futures):
+                    elements = future.result()
+                    all_elements.extend(elements)
+            
+            # Sort by page number to restore document order
+            all_elements.sort(key=lambda el: el.page_num)
+            
+            # Compute stats
             stats = {"code": 0, "table": 0, "prose": 0}
-            
-            for page_num, page in enumerate(doc, 1):
-                page_elements = self._extract_page_elements(page, page_num)
-                all_elements.extend(page_elements)
-                for el in page_elements:
-                    stats[el.type] += 1
-            
-            doc.close()
+            for el in all_elements:
+                stats[el.type] += 1
             
             logger.info(f"✅ Extracted {len(all_elements)} elements from {metadata['pages_count']} pages")
             logger.info(f"   Code blocks: {stats['code']}, Tables: {stats['table']}, Prose: {stats['prose']}")
@@ -181,6 +222,35 @@ class Indexer:
         except Exception as e:
             logger.error(f"❌ PDF extraction failed: {e}")
             raise
+
+    def _extract_page_range(
+        self, pdf_path: str, page_start: int, page_end: int
+        ) -> list[PDFElement]:
+        """
+        Extract elements from a range of pages using a thread-local document.
+
+        Each thread opens its own pymupdf.open() handle for thread safety.
+        PyMuPDF uses mmap internally, so multiple handles to the same file
+        share the underlying memory-mapped data with minimal overhead.
+
+        Args:
+            pdf_path: Path to PDF file
+            page_start: Start page index (0-based, inclusive)
+            page_end: End page index (0-based, exclusive)
+
+        Returns:
+            List of PDFElements with correct 1-indexed page numbers
+        """
+        doc = pymupdf.open(pdf_path)
+        elements = []
+        try:
+            for page_idx in range(page_start, page_end):
+                page = doc[page_idx]
+                page_elements = self._extract_page_elements(page, page_idx + 1)
+                elements.extend(page_elements)
+        finally:
+            doc.close()
+        return elements
     
     def _extract_page_elements(self, page, page_num: int) -> list[PDFElement]:
         """

--- a/backend/app/services/rag/indexer.py
+++ b/backend/app/services/rag/indexer.py
@@ -185,31 +185,41 @@ class Indexer:
     def _extract_page_elements(self, page, page_num: int) -> list[PDFElement]:
         """
         Extract typed elements from a single page.
-        
+
         Order: tables first → code blocks → prose (remaining text).
         Claimed regions prevent double-counting.
+
+        Parses page.get_text("dict") once and passes the block list
+        to both code and prose extractors to avoid redundant parsing.
         """
         elements = []
         claimed_regions = []  # list of (x0, y0, x1, y1) bboxes
-        
+
+        # Parse page structure once — shared by code + prose extractors
+        page_dict_blocks = page.get_text("dict")["blocks"]
+
         # ── 1. Extract tables ────────────────────────────────────────────
         table_elements = self._extract_tables(page, page_num)
         for el in table_elements:
             elements.append(el)
             if el.bbox:
                 claimed_regions.append(el.bbox)
-        
+
         # ── 2. Extract code blocks (monospace font spans) ────────────────
-        code_elements = self._extract_code_blocks(page, page_num, claimed_regions)
+        code_elements = self._extract_code_blocks(
+            page_dict_blocks, page_num, claimed_regions
+        )
         for el in code_elements:
             elements.append(el)
             if el.bbox:
                 claimed_regions.append(el.bbox)
-        
+
         # ── 3. Extract prose (everything not claimed) ────────────────────
-        prose_elements = self._extract_prose(page, page_num, claimed_regions)
+        prose_elements = self._extract_prose(
+            page_dict_blocks, page_num, claimed_regions
+        )
         elements.extend(prose_elements)
-        
+
         return elements
     
     def _extract_tables(self, page, page_num: int) -> list[PDFElement]:
@@ -248,7 +258,7 @@ class Indexer:
         return elements
     
     def _extract_code_blocks(
-        self, page, page_num: int, claimed_regions: list
+        self, blocks: list, page_num: int, claimed_regions: list
     ) -> list[PDFElement]:
         """
         Detect code blocks by scanning for monospace font spans.
@@ -259,7 +269,7 @@ class Indexer:
         elements = []
         
         try:
-            blocks = page.get_text("dict")["blocks"]
+            
             
             # Collect monospace blocks
             mono_blocks = []  # list of {"text": ..., "bbox": ...}
@@ -349,7 +359,7 @@ class Indexer:
         return elements
     
     def _extract_prose(
-        self, page, page_num: int, claimed_regions: list
+        self, blocks: list, page_num: int, claimed_regions: list
     ) -> list[PDFElement]:
         """
         Extract non-code, non-table text as prose.
@@ -360,7 +370,6 @@ class Indexer:
         elements = []
         
         try:
-            blocks = page.get_text("dict")["blocks"]
             prose_parts = []
             
             for block in blocks:

--- a/backend/app/services/rag/indexer.py
+++ b/backend/app/services/rag/indexer.py
@@ -39,6 +39,11 @@ logger = logging.getLogger(__name__)
 # thread-based parallelism effective for page parsing.
 EXTRACTION_WORKERS = 4
 
+
+# Batch size for sentence-transformers embedding generation.
+# bge-small-en-v1.5 (33M params) handles 64 comfortably on CPU.
+EMBEDDING_BATCH_SIZE = 64
+
 # Monospace font families used for code rendering in PDFs
 MONOSPACE_FONTS = {
     "courier", "consolas", "menlo", "monaco",
@@ -147,41 +152,41 @@ class Indexer:
     def extract_pdf_elements(self, pdf_path: str) -> tuple[list[PDFElement], dict]:
         """
         Extract typed elements (code, tables, prose) from a PDF.
-        
+
         Uses ThreadPoolExecutor to parallelize page extraction.
         Each thread opens its own document handle for thread safety.
         PyMuPDF releases the GIL during C-level operations, making
         threads effective for this workload.
-        
+
         Per page, extraction order:
         1. Tables (via find_tables) — mark regions as claimed
         2. Code blocks (via monospace font detection) — mark regions as claimed
         3. Prose (everything else)
-        
+
         Args:
             pdf_path: Path to PDF file
-            
+
         Returns:
             Tuple of (elements list, metadata dict)
         """
         try:
             logger.info(f"📄 Extracting structured elements from: {pdf_path}")
-            
+
             # Open briefly just to read page count and metadata
             doc = pymupdf.open(pdf_path)
             total_pages = len(doc)
             doc.close()
-            
+
             metadata = {
                 "pages_count": total_pages,
                 "file_size_bytes": Path(pdf_path).stat().st_size,
             }
-            
+
             # Split pages into ranges for parallel extraction
             workers = min(EXTRACTION_WORKERS, total_pages)
             pages_per_worker = total_pages // workers
             remainder = total_pages % workers
-            
+
             ranges = []
             start = 0
             for i in range(workers):
@@ -189,9 +194,9 @@ class Indexer:
                 end = start + pages_per_worker + (1 if i < remainder else 0)
                 ranges.append((start, end))
                 start = end
-            
+
             logger.info(f"   Parallelizing extraction: {workers} workers, {total_pages} pages")
-            
+
             # Extract in parallel — each worker opens its own doc handle
             all_elements = []
             with ThreadPoolExecutor(max_workers=workers) as executor:
@@ -201,24 +206,24 @@ class Indexer:
                     ): r
                     for r in ranges
                 }
-                
+
                 for future in as_completed(futures):
                     elements = future.result()
                     all_elements.extend(elements)
-            
+
             # Sort by page number to restore document order
             all_elements.sort(key=lambda el: el.page_num)
-            
+
             # Compute stats
             stats = {"code": 0, "table": 0, "prose": 0}
             for el in all_elements:
                 stats[el.type] += 1
-            
+
             logger.info(f"✅ Extracted {len(all_elements)} elements from {metadata['pages_count']} pages")
             logger.info(f"   Code blocks: {stats['code']}, Tables: {stats['table']}, Prose: {stats['prose']}")
-            
+
             return all_elements, metadata
-            
+
         except Exception as e:
             logger.error(f"❌ PDF extraction failed: {e}")
             raise
@@ -686,7 +691,7 @@ class Indexer:
             chunk_texts = [c["text"] for c in chunks]
             embeddings = self.embedder.embed_batch(
                 chunk_texts,
-                batch_size=32,
+                batch_size=EMBEDDING_BATCH_SIZE,
                 show_progress=True
             )
             

--- a/backend/app/services/rag/indexer.py
+++ b/backend/app/services/rag/indexer.py
@@ -34,10 +34,7 @@ from app.services.rag.chunker import get_chunker
 logger = logging.getLogger(__name__)
 
 
-# Number of threads for parallel page extraction.
-# PyMuPDF releases the GIL during C-level operations, making
-# thread-based parallelism effective for page parsing.
-EXTRACTION_WORKERS = 4
+
 
 
 # Batch size for sentence-transformers embedding generation.
@@ -183,7 +180,7 @@ class Indexer:
             }
 
             # Split pages into ranges for parallel extraction
-            workers = min(EXTRACTION_WORKERS, total_pages)
+            workers = min(settings.EXTRACTION_WORKERS, total_pages)
             pages_per_worker = total_pages // workers
             remainder = total_pages % workers
 
@@ -691,7 +688,7 @@ class Indexer:
             chunk_texts = [c["text"] for c in chunks]
             embeddings = self.embedder.embed_batch(
                 chunk_texts,
-                batch_size=EMBEDDING_BATCH_SIZE,
+                batch_size=settings.EMBEDDING_BATCH_SIZE,
                 show_progress=True
             )
             

--- a/backend/app/services/rag/indexer.py
+++ b/backend/app/services/rag/indexer.py
@@ -12,7 +12,6 @@ Pipeline:
 """
 import logging
 import pymupdf  # PyMuPDF (fitz)
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Dict, Optional
@@ -150,11 +149,6 @@ class Indexer:
         """
         Extract typed elements (code, tables, prose) from a PDF.
 
-        Uses ThreadPoolExecutor to parallelize page extraction.
-        Each thread opens its own document handle for thread safety.
-        PyMuPDF releases the GIL during C-level operations, making
-        threads effective for this workload.
-
         Per page, extraction order:
         1. Tables (via find_tables) — mark regions as claimed
         2. Code blocks (via monospace font detection) — mark regions as claimed
@@ -169,52 +163,23 @@ class Indexer:
         try:
             logger.info(f"📄 Extracting structured elements from: {pdf_path}")
 
-            # Open briefly just to read page count and metadata
             doc = pymupdf.open(pdf_path)
-            total_pages = len(doc)
-            doc.close()
 
             metadata = {
-                "pages_count": total_pages,
+                "pages_count": len(doc),
                 "file_size_bytes": Path(pdf_path).stat().st_size,
             }
 
-            # Split pages into ranges for parallel extraction
-            workers = min(settings.EXTRACTION_WORKERS, total_pages)
-            pages_per_worker = total_pages // workers
-            remainder = total_pages % workers
-
-            ranges = []
-            start = 0
-            for i in range(workers):
-                # Distribute remainder pages across first N workers
-                end = start + pages_per_worker + (1 if i < remainder else 0)
-                ranges.append((start, end))
-                start = end
-
-            logger.info(f"   Parallelizing extraction: {workers} workers, {total_pages} pages")
-
-            # Extract in parallel — each worker opens its own doc handle
             all_elements = []
-            with ThreadPoolExecutor(max_workers=workers) as executor:
-                futures = {
-                    executor.submit(
-                        self._extract_page_range, pdf_path, r[0], r[1]
-                    ): r
-                    for r in ranges
-                }
-
-                for future in as_completed(futures):
-                    elements = future.result()
-                    all_elements.extend(elements)
-
-            # Sort by page number to restore document order
-            all_elements.sort(key=lambda el: el.page_num)
-
-            # Compute stats
             stats = {"code": 0, "table": 0, "prose": 0}
-            for el in all_elements:
-                stats[el.type] += 1
+
+            for page_num, page in enumerate(doc, 1):
+                page_elements = self._extract_page_elements(page, page_num)
+                all_elements.extend(page_elements)
+                for el in page_elements:
+                    stats[el.type] += 1
+
+            doc.close()
 
             logger.info(f"✅ Extracted {len(all_elements)} elements from {metadata['pages_count']} pages")
             logger.info(f"   Code blocks: {stats['code']}, Tables: {stats['table']}, Prose: {stats['prose']}")
@@ -297,11 +262,9 @@ class Indexer:
     def _extract_tables(self, page, page_num: int) -> list[PDFElement]:
         """Extract tables using PyMuPDF's built-in table detection."""
 
-        # Quick pre-check: skip expensive layout analysis if no ruling lines
-        if not self._page_has_table_indicators(page):
-            logger.debug(f"   Skipping table detection on page {page_num}: no line drawings")
-            return elements
         elements = []
+        
+        
         
         try:
             tables = page.find_tables()
@@ -334,24 +297,7 @@ class Indexer:
         
         return elements
     
-    @staticmethod
-    def _page_has_table_indicators(page) -> bool:
-        """
-        Quick check for ruling lines that indicate table presence.
-
-        Tables in PDFs are almost always rendered with horizontal/vertical
-        lines ("l") or rectangles ("re"). Pages without these drawing
-        commands overwhelmingly have no tables, so we can skip the
-        expensive find_tables() layout analysis.
-        """
-        try:
-            for drawing in page.get_drawings():
-                for item in drawing["items"]:
-                    if item[0] in ("l", "re"):  # line or rectangle
-                        return True
-        except Exception:
-            return True  # if check fails, fall through to find_tables()
-        return False
+    
     
     def _extract_code_blocks(
         self, blocks: list, page_num: int, claimed_regions: list

--- a/backend/app/services/rag/indexer.py
+++ b/backend/app/services/rag/indexer.py
@@ -224,6 +224,11 @@ class Indexer:
     
     def _extract_tables(self, page, page_num: int) -> list[PDFElement]:
         """Extract tables using PyMuPDF's built-in table detection."""
+
+        # Quick pre-check: skip expensive layout analysis if no ruling lines
+        if not self._page_has_table_indicators(page):
+            logger.debug(f"   Skipping table detection on page {page_num}: no line drawings")
+            return elements
         elements = []
         
         try:
@@ -256,6 +261,25 @@ class Indexer:
             logger.debug(f"   Table extraction failed on page {page_num}: {e}")
         
         return elements
+    
+    @staticmethod
+    def _page_has_table_indicators(page) -> bool:
+        """
+        Quick check for ruling lines that indicate table presence.
+
+        Tables in PDFs are almost always rendered with horizontal/vertical
+        lines ("l") or rectangles ("re"). Pages without these drawing
+        commands overwhelmingly have no tables, so we can skip the
+        expensive find_tables() layout analysis.
+        """
+        try:
+            for drawing in page.get_drawings():
+                for item in drawing["items"]:
+                    if item[0] in ("l", "re"):  # line or rectangle
+                        return True
+        except Exception:
+            return True  # if check fails, fall through to find_tables()
+        return False
     
     def _extract_code_blocks(
         self, blocks: list, page_num: int, claimed_regions: list

--- a/backend/app/tasks/cleanup_tasks.py
+++ b/backend/app/tasks/cleanup_tasks.py
@@ -1,0 +1,44 @@
+"""
+Cleanup Background Tasks
+
+Periodic tasks for housekeeping (temp file cleanup, etc.)
+"""
+import logging
+import time
+from pathlib import Path
+
+from app.celery_app import celery_app
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task(name="codementor.cleanup-uploads")
+def cleanup_uploads_task():
+    """
+    Delete uploaded files older than UPLOAD_RETENTION_HOURS.
+    
+    Runs periodically via Celery Beat to prevent disk accumulation.
+    Files are safe to delete after indexing completes (or fails permanently),
+    since all content is stored in Qdrant vectors.
+    """
+    upload_dir = Path(settings.UPLOAD_DIR)
+    
+    if not upload_dir.exists():
+        return []
+    
+    cutoff = time.time() - (settings.UPLOAD_RETENTION_HOURS * 3600)
+    deleted = []
+    
+    for f in upload_dir.iterdir():
+        if f.is_file() and f.stat().st_mtime < cutoff:
+            try:
+                f.unlink()
+                deleted.append(f.name)
+            except OSError as e:
+                logger.warning(f"⚠️  Could not delete {f.name}: {e}")
+    
+    if deleted:
+        logger.info(f"🗑️  Cleaned up {len(deleted)} expired uploads")
+    
+    return deleted

--- a/backend/app/tasks/rag_tasks.py
+++ b/backend/app/tasks/rag_tasks.py
@@ -4,6 +4,8 @@ RAG Background Tasks
 Celery tasks for processing PDFs asynchronously.
 """
 import logging
+import uuid
+from qdrant_client.models import PointStruct
 from app.celery_app import celery_app
 from app.db.session import SessionLocal
 from app.models.rag_document import RAGDocument
@@ -28,48 +30,105 @@ def process_pdf_task(self, document_id: int, file_path: str):
     
     try:
         logger.info(f"📄 Processing document {document_id} from {file_path}")
-        
+
         # Get document from database
         document = db.query(RAGDocument).filter(RAGDocument.id == document_id).first()
-        
+
         if not document:
             logger.error(f"❌ Document {document_id} not found in database")
             return
-        
+
         # Update status to processing
         document.status = "processing"
         db.commit()
-        
-        # Initialize indexer
+
         indexer = get_indexer()
-        
-        # Index the PDF
-        logger.info(f"🔄 Starting indexing for document {document_id}")
-        chunks_count = indexer.index_pdf(
-            pdf_path=file_path,
-            collection_name=settings.QDRANT_COLLECTION,
-            metadata={
-                "document_id": document.id,
-                "user_id": document.user_id,
-                "title": document.title,
-                "language": "java",  # Legacy field (TODO: remove)
-                "topic": document.topic,  # 🆕 NEW!
-                "is_public": document.is_public
-            }
+
+        pdf_metadata = {
+            "document_id": document.id,
+            "user_id": document.user_id,
+            "title": document.title,
+            "language": "java",  # Legacy field (TODO: remove)
+            "topic": document.topic,
+            "is_public": document.is_public
+        }
+
+        # ── Stage 1: Extract ─────────────────────────────────────────
+        self.update_state(state='PROGRESS', meta={
+            'stage': 'extracting',
+            'detail': 'Extracting text, code blocks, and tables from PDF...',
+        })
+        elements, pdf_meta = indexer.extract_pdf_elements(file_path)
+
+        if not elements:
+            raise ValueError("No elements extracted from PDF")
+
+        # ── Stage 2: Chunk ───────────────────────────────────────────
+        self.update_state(state='PROGRESS', meta={
+            'stage': 'chunking',
+            'detail': f'Chunking {len(elements)} elements...',
+        })
+        chunks = indexer._chunk_elements(elements)
+
+        if not chunks:
+            raise ValueError("No chunks generated from elements")
+
+        # ── Stage 3: Embed ───────────────────────────────────────────
+        self.update_state(state='PROGRESS', meta={
+            'stage': 'embedding',
+            'detail': f'Generating embeddings for {len(chunks)} chunks...',
+        })
+        chunk_texts = [c["text"] for c in chunks]
+        embeddings = indexer.embedder.embed_batch(
+            chunk_texts,
+            batch_size=settings.EMBEDDING_BATCH_SIZE,
+            show_progress=True
         )
-        
+
+        # ── Stage 4: Upload ──────────────────────────────────────────
+        self.update_state(state='PROGRESS', meta={
+            'stage': 'uploading',
+            'detail': f'Uploading {len(chunks)} vectors to Qdrant...',
+        })
+        indexer._ensure_collection(settings.QDRANT_COLLECTION)
+
+        # Prepare and upload points
+        points = []
+        for i, (chunk, embedding) in enumerate(zip(chunks, embeddings)):
+            point_metadata = {
+                **pdf_metadata,
+                "chunk_index": i,
+                "chunk_text": chunk["text"],
+                "chunk_type": chunk["chunk_type"],
+                "page_numbers": chunk["page_numbers"],
+                "pages_count": pdf_meta["pages_count"],
+                "file_size_bytes": pdf_meta["file_size_bytes"],
+            }
+            points.append(PointStruct(
+                id=str(uuid.uuid4()),
+                vector=embedding.tolist(),
+                payload=point_metadata
+            ))
+
+        indexer.client.upsert(
+            collection_name=settings.QDRANT_COLLECTION,
+            points=points,
+            wait=True
+        )
+
+        chunks_count = len(chunks)
         logger.info(f"✅ Indexed {chunks_count} chunks for document {document_id}")
-        
+
         # Update document status
         document.status = "completed"
         document.chunks_count = chunks_count
         db.commit()
-        
+
         logger.info(f"✅ Document {document_id} processed successfully")
         
     except Exception as e:
         logger.error(f"❌ Error processing document {document_id}: {e}")
-        
+
         # Attempt retry with exponential backoff.
         # Only mark as "failed" when all retries are exhausted.
         try:

--- a/backend/app/tasks/rag_tasks.py
+++ b/backend/app/tasks/rag_tasks.py
@@ -70,21 +70,28 @@ def process_pdf_task(self, document_id: int, file_path: str):
     except Exception as e:
         logger.error(f"❌ Error processing document {document_id}: {e}")
         
-        # Update document with error
+        # Attempt retry with exponential backoff.
+        # Only mark as "failed" when all retries are exhausted.
         try:
-            document = db.query(RAGDocument).filter(RAGDocument.id == document_id).first()
-            if document:
-                document.status = "failed"
-                document.error_message = str(e)[:500]  # Limit error message length
-                db.commit()
-        except Exception as update_error:
-            logger.error(f"❌ Failed to update error status: {update_error}")
-        
-        # Retry task
-        try:
-            raise self.retry(exc=e, countdown=60)
+            countdown = 60 * (2 ** self.request.retries)
+            logger.info(
+                f"🔄 Retrying document {document_id} "
+                f"(attempt {self.request.retries + 1}/{self.max_retries}), "
+                f"next retry in {countdown}s"
+            )
+            self.retry(exc=e, countdown=countdown)
         except self.MaxRetriesExceededError:
             logger.error(f"❌ Max retries exceeded for document {document_id}")
+            try:
+                document = db.query(RAGDocument).filter(
+                    RAGDocument.id == document_id
+                ).first()
+                if document:
+                    document.status = "failed"
+                    document.error_message = str(e)[:500]
+                    db.commit()
+            except Exception as update_error:
+                logger.error(f"❌ Failed to update error status: {update_error}")
     
     finally:
         db.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pydantic-settings>=2.12.0",
     "pydantic[email]>=2.12.5",
     "pymupdf>=1.27.1",
+    "pymupdf-layout>=1.27.1",
     "python-dotenv>=1.2.1",
     "python-jose[cryptography]>=3.5.0",
     "python-multipart>=0.0.22",

--- a/uv.lock
+++ b/uv.lock
@@ -534,6 +534,7 @@ dependencies = [
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
     { name = "pymupdf" },
+    { name = "pymupdf-layout" },
     { name = "python-dotenv" },
     { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
@@ -570,6 +571,7 @@ requires-dist = [
     { name = "pydantic", extras = ["email"], specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "pymupdf", specifier = ">=1.27.1" },
+    { name = "pymupdf-layout", specifier = ">=1.27.1" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.5.0" },
     { name = "python-multipart", specifier = ">=0.0.22" },
@@ -968,6 +970,14 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb", size = 998020, upload-time = "2022-11-02T17:34:04.141Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970, upload-time = "2022-11-02T17:34:01.425Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
 ]
 
 [[package]]
@@ -2252,6 +2262,39 @@ wheels = [
 ]
 
 [[package]]
+name = "onnxruntime"
+version = "1.24.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/7f/dfdc4e52600fde4c02d59bfe98c4b057931c1114b701e175aee311a9bc11/onnxruntime-1.24.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:0d244227dc5e00a9ae15a7ac1eba4c4460d7876dfecafe73fb00db9f1d914d91", size = 17342578, upload-time = "2026-03-05T17:19:02.403Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/dc/1f5489f7b21817d4ad352bf7a92a252bd5b438bcbaa7ad20ea50814edc79/onnxruntime-1.24.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a9847b870b6cb462652b547bc98c49e0efb67553410a082fde1918a38707452", size = 15150105, upload-time = "2026-03-05T16:34:56.897Z" },
+    { url = "https://files.pythonhosted.org/packages/28/7c/fd253da53594ab8efbefdc85b3638620ab1a6aab6eb7028a513c853559ce/onnxruntime-1.24.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b354afce3333f2859c7e8706d84b6c552beac39233bcd3141ce7ab77b4cabb5d", size = 17237101, upload-time = "2026-03-05T17:18:02.561Z" },
+    { url = "https://files.pythonhosted.org/packages/71/5f/eaabc5699eeed6a9188c5c055ac1948ae50138697a0428d562ac970d7db5/onnxruntime-1.24.3-cp312-cp312-win_amd64.whl", hash = "sha256:44ea708c34965439170d811267c51281d3897ecfc4aa0087fa25d4a4c3eb2e4a", size = 12597638, upload-time = "2026-03-05T17:18:52.141Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/5c/d8066c320b90610dbeb489a483b132c3b3879b2f93f949fb5d30cfa9b119/onnxruntime-1.24.3-cp312-cp312-win_arm64.whl", hash = "sha256:48d1092b44ca2ba6f9543892e7c422c15a568481403c10440945685faf27a8d8", size = 12270943, upload-time = "2026-03-05T17:18:42.006Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8d/487ece554119e2991242d4de55de7019ac6e47ee8dfafa69fcf41d37f8ed/onnxruntime-1.24.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:34a0ea5ff191d8420d9c1332355644148b1bf1a0d10c411af890a63a9f662aa7", size = 17342706, upload-time = "2026-03-05T16:35:10.813Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/25/8b444f463c1ac6106b889f6235c84f01eec001eaf689c3eff8c69cf48fae/onnxruntime-1.24.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fd2ec7bb0fabe42f55e8337cfc9b1969d0d14622711aac73d69b4bd5abb5ed7", size = 15149956, upload-time = "2026-03-05T16:34:59.264Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fc/c9182a3e1ab46940dd4f30e61071f59eee8804c1f641f37ce6e173633fb6/onnxruntime-1.24.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df8e70e732fe26346faaeec9147fa38bef35d232d2495d27e93dd221a2d473a9", size = 17237370, upload-time = "2026-03-05T17:18:05.258Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/3b549e1f4538514118bff98a1bcd6481dd9a17067f8c9af77151621c9a5c/onnxruntime-1.24.3-cp313-cp313-win_amd64.whl", hash = "sha256:2d3706719be6ad41d38a2250998b1d87758a20f6ea4546962e21dc79f1f1fd2b", size = 12597939, upload-time = "2026-03-05T17:18:54.772Z" },
+    { url = "https://files.pythonhosted.org/packages/80/41/9696a5c4631a0caa75cc8bc4efd30938fd483694aa614898d087c3ee6d29/onnxruntime-1.24.3-cp313-cp313-win_arm64.whl", hash = "sha256:b082f3ba9519f0a1a1e754556bc7e635c7526ef81b98b3f78da4455d25f0437b", size = 12270705, upload-time = "2026-03-05T17:18:44.774Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/65/a26c5e59e3b210852ee04248cf8843c81fe7d40d94cf95343b66efe7eec9/onnxruntime-1.24.3-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72f956634bc2e4bd2e8b006bef111849bd42c42dea37bd0a4c728404fdaf4d34", size = 15161796, upload-time = "2026-03-05T16:35:02.871Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/25/2035b4aa2ccb5be6acf139397731ec507c5f09e199ab39d3262b22ffa1ac/onnxruntime-1.24.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78d1f25eed4ab9959db70a626ed50ee24cf497e60774f59f1207ac8556399c4d", size = 17240936, upload-time = "2026-03-05T17:18:09.534Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/a4/b3240ea84b92a3efb83d49cc16c04a17ade1ab47a6a95c4866d15bf0ac35/onnxruntime-1.24.3-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a6b4bce87d96f78f0a9bf5cefab3303ae95d558c5bfea53d0bf7f9ea207880a8", size = 17344149, upload-time = "2026-03-05T16:35:13.382Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/4a/4b56757e51a56265e8c56764d9c36d7b435045e05e3b8a38bedfc5aedba3/onnxruntime-1.24.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d48f36c87b25ab3b2b4c88826c96cf1399a5631e3c2c03cc27d6a1e5d6b18eb4", size = 15151571, upload-time = "2026-03-05T16:35:05.679Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/14/c6fb84980cec8f682a523fcac7c2bdd6b311e7f342c61ce48d3a9cb87fc6/onnxruntime-1.24.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e104d33a409bf6e3f30f0e8198ec2aaf8d445b8395490a80f6e6ad56da98e400", size = 17238951, upload-time = "2026-03-05T17:18:12.394Z" },
+    { url = "https://files.pythonhosted.org/packages/57/14/447e1400165aca8caf35dabd46540eb943c92f3065927bb4d9bcbc91e221/onnxruntime-1.24.3-cp314-cp314-win_amd64.whl", hash = "sha256:e785d73fbd17421c2513b0bb09eb25d88fa22c8c10c3f5d6060589efa5537c5b", size = 12903820, upload-time = "2026-03-05T17:18:57.123Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ec/6b2fa5702e4bbba7339ca5787a9d056fc564a16079f8833cc6ba4798da1c/onnxruntime-1.24.3-cp314-cp314-win_arm64.whl", hash = "sha256:951e897a275f897a05ffbcaa615d98777882decaeb80c9216c68cdc62f849f53", size = 12594089, upload-time = "2026-03-05T17:18:47.169Z" },
+    { url = "https://files.pythonhosted.org/packages/12/dc/cd06cba3ddad92ceb17b914a8e8d49836c79e38936e26bde6e368b62c1fe/onnxruntime-1.24.3-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d4e70ce578aa214c74c7a7a9226bc8e229814db4a5b2d097333b81279ecde36", size = 15162789, upload-time = "2026-03-05T16:35:08.282Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/d6/413e98ab666c6fb9e8be7d1c6eb3bd403b0bea1b8d42db066dab98c7df07/onnxruntime-1.24.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02aaf6ddfa784523b6873b4176a79d508e599efe12ab0ea1a3a6e7314408b7aa", size = 17240738, upload-time = "2026-03-05T17:18:15.203Z" },
+]
+
+[[package]]
 name = "opencv-python"
 version = "4.13.0.92"
 source = { registry = "https://pypi.org/simple" }
@@ -2794,6 +2837,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/29/690202b38b93cf77b73a29c25a63a2b6f3fcb36b1f75006e50b8dee7c108/pymupdf-1.27.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4f1837554134fb45d390a44de8844b2ca9b6c901c82ccc90b340e3b7f3b126ca", size = 25167965, upload-time = "2026-02-11T22:36:35.478Z" },
     { url = "https://files.pythonhosted.org/packages/8a/81/f937e6aa606fd263c3a45d0ff0f0bbdbf3fb779933091fc0f6179513cc93/pymupdf-1.27.1-cp310-abi3-win32.whl", hash = "sha256:fa33b512d82c6c4852edadf57f22d5f27d16243bb33dac0fbe4eb0f281c5b17e", size = 18006253, upload-time = "2026-02-12T13:48:07.129Z" },
     { url = "https://files.pythonhosted.org/packages/3e/99/fe4a7752990bf65277718fffbead4478de9afd1c7288d7a6d643f79a6fa7/pymupdf-1.27.1-cp310-abi3-win_amd64.whl", hash = "sha256:4b6268dff3a9d713034eba5c2ffce0da37c62443578941ac5df433adcde57b2f", size = 19236703, upload-time = "2026-02-11T15:04:19.607Z" },
+]
+
+[[package]]
+name = "pymupdf-layout"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "pymupdf" },
+    { name = "pyyaml" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ac/574f537fa0199b31755eb0859d8e6ed8fcc669f7b460eba78611d1d78c8a/pymupdf_layout-1.27.1-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e60b7238f7652a825a884641fc1e9070e3b385905891ae194dfe91e5932b2342", size = 12323338, upload-time = "2026-02-11T16:23:52.453Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0b/b83178bb88cc8933f61dac113c89be9be426fd7c3b9deca3b628e96eb99a/pymupdf_layout-1.27.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:888923391e155cb6a4e0498709c8f4da750858dc273417a7386aeb8b81009b83", size = 12318712, upload-time = "2026-02-11T16:24:01.194Z" },
+    { url = "https://files.pythonhosted.org/packages/66/e4/d11ebba2e950606713495620503d0e1b627c879c708fc488f7167cfb35a3/pymupdf_layout-1.27.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:05d88e0060b5875d21ee53c1dc50a2454aa32e59048b971847782318f47dca11", size = 12328732, upload-time = "2026-02-11T22:33:46.923Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/b6/0278408e2f6db993e3c9d4ee7be89f01b0022233298aa20fe54b95a0169c/pymupdf_layout-1.27.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:e9e10d96f06ef5f511523a7caf5b707596a60c5c0a4735f4c5f84728cdb75ffd", size = 12329763, upload-time = "2026-02-11T16:24:09.825Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/2c/f96920afb5a17226e7475f5db9eb7755a019623984caedcb47cb16660bd2/pymupdf_layout-1.27.1-cp310-abi3-win_amd64.whl", hash = "sha256:e456bcdc8760caadcaecb57e96277de11f9cdde785b04bf535448df4fb1e25fc", size = 12332980, upload-time = "2026-02-11T16:24:17.523Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #5

## feat: indexing performance + Celery hardening

### Celery fixes
- **Retry status fix**: moved `status="failed"` into `MaxRetriesExceededError` block only — no more frontend flicker during retries. Added exponential backoff (60s → 120s → 240s).
- **Periodic file cleanup**: new `cleanup_uploads_task` deletes files older than 24h. Runs hourly via Celery Beat.
- **Worker tuning**: `max_tasks_per_child` 50→200 (fewer model reloads), `broker_pool_limit=0`, explicit `--concurrency=2`.
- **Progress reporting**: `update_state()` at each pipeline stage (extracting → chunking → embedding → uploading).

### Indexer refactor
- Parse `page.get_text("dict")` once per page, pass to both code/prose extractors (was called twice).
- `SemanticChunker` now uses GPU via `SentenceTransformerEmbeddings(device=settings.EMBEDDING_DEVICE)`.
- Embedding batch size configurable via `EMBEDDING_BATCH_SIZE` (default 64, was hardcoded 32).

### What didn't work (tried and reverted)
- `ThreadPoolExecutor` for parallel page extraction — PyMuPDF's `find_tables()` doesn't release the GIL effectively, threads contended instead of parallelizing.
- `get_drawings()` heuristic to skip `find_tables()` — most textbook pages have decorative lines, heuristic triggered on nearly every page adding overhead.

### Files changed
- `backend/app/tasks/rag_tasks.py` — retry fix + progress reporting
- `backend/app/tasks/cleanup_tasks.py` — new periodic cleanup task
- `backend/app/celery_app.py` — beat schedule, worker config, task includes
- `backend/app/core/config.py` — `UPLOAD_RETENTION_HOURS`, `EMBEDDING_BATCH_SIZE`
- `backend/app/services/rag/indexer.py` — single dict parse, batch size constant
- `backend/app/services/rag/chunker.py` — GPU-backed `SentenceTransformerEmbeddings`
- `Makefile` — `celery-beat` target, `--concurrency=2`
- `docker-compose.yml` — `--concurrency=2`