### PR TITLE
fix: add END_OF_MESSAGE sentinel and graceful stream error handling

### DIFF
--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -11,6 +11,7 @@ from app.db.session import get_db
 from app.models import User
 from app.core.deps import get_current_active_user
 from app.services import chat_service
+from app.services.chat_service import END_OF_MESSAGE
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -101,7 +102,7 @@ async def chat_stream(
                 if item["type"] == "chunk":
                     # Send content chunks
                     yield f"data: {json.dumps({'content': item['content']})}\n\n"
-                    await asyncio.sleep(0.08)  # Visible streaming delay
+                    #await asyncio.sleep(0.08)  # Visible streaming delay
                     
                 elif item["type"] == "done":
                     # Got final metadata
@@ -129,7 +130,7 @@ async def chat_stream(
                         rag_used = True
                     
                     # Send done signal with metadata
-                    yield f"data: {json.dumps({
+                    yield (f"data: {json.dumps({
                         'done': True,
                         'conversation_id': conversation_id,
                         'message_id': message_id,
@@ -137,15 +138,18 @@ async def chat_stream(
                         'rag_used': rag_used,  # 🆕 NEW: Whether RAG was used
                         'conversation_title': conversation_title
                     })}\n\n"
+                        f"data: {END_OF_MESSAGE}\n\n")
                     
                     logger.info(f"✅ Streaming complete (conversation: {conversation_id}, RAG used: {rag_used})")
         
         except ValueError as e:
             logger.error(f"❌ Chat error: {e}")
-            yield f"data: {json.dumps({'error': str(e)})}\n\n"
+            yield f"data: {json.dumps({'error': str(e), 'sources': [], 'done': True})}\n\n"
+            yield f"data: {END_OF_MESSAGE}\n\n"
         except Exception as e:
             logger.error(f"❌ Streaming error: {e}")
-            yield f"data: {json.dumps({'error': 'Internal server error'})}\n\n"
+            yield f"data: {json.dumps({'error': 'Internal server error', 'sources': [], 'done': True})}\n\n"
+            yield f"data: {END_OF_MESSAGE}\n\n"
     
     return StreamingResponse(
         generate(),

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -8,6 +8,8 @@ from app.models import Conversation, Message
 from app.services.llm import llm_service
 from app.services.rag_service import get_rag_service
 
+END_OF_MESSAGE = "[END_OF_MESSAGE]"
+
 logger = logging.getLogger(__name__)
 
 # Initialize RAG service

--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -170,7 +170,7 @@ Remember: Your goal is to help students truly understand concepts, not just pass
             
         except Exception as e:
             logger.error(f"❌ Streaming error: {e}")
-            yield f"Error: {str(e)}"
+            raise
     
     def health_check(self) -> bool:
         """

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -226,34 +226,34 @@ export const streamMessage = async (
   const reader  = response.body.getReader();
   const decoder = new TextDecoder();
 
-  while (true) {
+  let streamDone = false;
+
+while (true) {
     const { done, value } = await reader.read();
     if (done) break;
 
-    const text  = decoder.decode(value);
+    const text = decoder.decode(value);
     const lines = text.split('\n');
 
     for (const line of lines) {
-      if (line.startsWith('data: ')) {
-        const data = line.slice(6);
-        if (!data) continue;
-        try {
-          const parsed = JSON.parse(data);
-          if (parsed.content) onChunk(parsed.content);
-          if (parsed.done) onDone(
-            parsed.conversation_id,
-            parsed.message_id,
-            parsed.sources  ?? [],
-            parsed.rag_used ?? false,
-            parsed.conversation_title ?? null,
-          );
-          if (parsed.error) throw new Error(parsed.error);
-        } catch  {
-          // Skip malformed JSON chunks
+        if (line.startsWith('data: ')) {
+            const data = line.slice(6);
+            if (!data) continue;
+
+            if (data === '[END_OF_MESSAGE]') { streamDone = true; break; }
+
+            try {
+                const parsed = JSON.parse(data);
+                if (parsed.content) onChunk(parsed.content);
+                if (parsed.done) onDone(parsed.conversation_id, parsed.message_id, parsed.sources ?? [], parsed.rag_used ?? false, parsed.conversation_title ?? null);
+                if (parsed.error) throw new Error(parsed.error);
+            } catch {
+                // skip malformed chunks
+            }
         }
-      }
     }
-  }
+    if (streamDone) break;
+}
 };
 
 export const searchAPI = {


### PR DESCRIPTION
Two bugs in the error path left the frontend in a permanent loading state on any stream failure:
1. llm.py yielded raw text on error instead of valid SSE JSON, causing JSON.parse() to throw on the frontend
2. chat.py error blocks never sent a terminal signal, leaving the SSE connection open and the spinner running forever

Fix by propagating exceptions from llm.py up to chat.py, and guaranteeing every exit point in the generate() function yields an END_OF_MESSAGE sentinel so the frontend always knows the stream is finished.



Closes #9 