### PR TITLE
fix: add context window truncation guard for qwen2.5-coder:7b

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -25,6 +25,8 @@ class Settings(BaseSettings):
     # ============ LLM (Ollama) ============
     OLLAMA_HOST: str = "http://localhost:11434"
     OLLAMA_MODEL: str = "qwen2.5-coder:7b"
+    OLLAMA_CONTEXT_WINDOW: int = 100   # qwen2.5-coder:7b max tokens
+    CONTEXT_WINDOW_BUFFER: int = 4096
     
     # ============ RAG - Qdrant ============
     QDRANT_HOST: str = "localhost"

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -1,3 +1,5 @@
+from pyexpat.errors import messages
+
 from sqlalchemy.orm import Session
 from typing import Optional, Dict
 from datetime import datetime
@@ -60,6 +62,41 @@ RAG_PROMPT_TEMPLATE = """Based on the following reference materials from your up
 Question: {question}
 
 Please answer using the information from these materials when relevant. If the materials don't fully cover the question, supplement with your general knowledge."""
+
+def count_tokens(text: str) -> int:
+    """Approximate token count using 4 chars per token heuristic."""
+    return len(text) // 4
+
+
+def condense_messages(
+    messages: list[dict],
+    system_prompt: str,
+    max_tokens: int
+) -> list[dict]:
+    """
+    Drop oldest messages until total token count fits within max_tokens.
+    Always preserves the last message (current user turn).
+    """
+    system_tokens = count_tokens(system_prompt)
+
+    def total_tokens(msgs):
+        return system_tokens + sum(count_tokens(m["content"]) for m in msgs)
+
+    original_count = len(messages)
+    while total_tokens(messages) > max_tokens and len(messages) > 1:
+        messages = messages[1:]  # drop oldest
+
+    dropped = original_count - len(messages)
+    if dropped:
+        logger.warning(
+            f"⚠️ Context window: dropped {dropped} oldest message(s) "
+            f"to fit within {max_tokens} tokens"
+        )
+
+    return messages
+
+
+
 
 
 def build_rag_enhanced_message(context: str, question: str) -> str:
@@ -244,6 +281,11 @@ def process_chat_message(
     
     # 4. Get LLM response (with enhanced message if RAG was used)
     messages = history + [{"role": "user", "content": enhanced_message}]
+    messages = condense_messages(
+    messages,
+    system_prompt=llm_service.SYSTEM_PROMPT,
+    max_tokens=settings.OLLAMA_CONTEXT_WINDOW - settings.CONTEXT_WINDOW_BUFFER
+)
     assistant_response = llm_service.chat(messages, temperature)
     
     # 5. Save assistant message
@@ -330,6 +372,11 @@ Question: {user_message}
     
     # 4. Stream LLM response and accumulate
     messages = history + [{"role": "user", "content": enhanced_message}]
+    messages = condense_messages(
+        messages,
+        system_prompt=llm_service.SYSTEM_PROMPT,
+        max_tokens=settings.OLLAMA_CONTEXT_WINDOW - settings.CONTEXT_WINDOW_BUFFER
+    )
     accumulated_response = ""
     
     async for chunk in llm_service.chat_stream(messages, temperature):


### PR DESCRIPTION
Large RAG context + long conversation history can silently overflow qwen2.5-coder:7b's 32k token context window. Ollama does not raise an error — it truncates or degrades output with no signal.

Add condense_messages() which iteratively drops the oldest messages until the full payload fits within the configured token budget. Token counting uses the 4 chars/token approximation to avoid adding a tokenizer dependency.

Closes #11 