### PR TITLE
feat: add X-Process-Time response header middleware

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,8 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
+from app.middleware.timing import add_process_time_header
+from starlette.middleware.base import BaseHTTPMiddleware
 import logging
 
 from app.core.config import settings
@@ -39,6 +41,7 @@ app.add_middleware(
     allow_methods=["*"],  # Allow all HTTP methods
     allow_headers=["*"],  # Allow all headers
 )
+app.add_middleware(BaseHTTPMiddleware, dispatch=add_process_time_header)
 
 @app.on_event("startup")
 async def startup_event():

--- a/backend/app/middleware/timing.py
+++ b/backend/app/middleware/timing.py
@@ -1,0 +1,13 @@
+import time
+import logging
+from fastapi import Request
+
+logger = logging.getLogger(__name__)
+
+async def add_process_time_header(request: Request, call_next):
+    start = time.perf_counter_ns()
+    response = await call_next(request)
+    duration_ms = (time.perf_counter_ns() - start) / 1_000_000
+    response.headers["X-Process-Time"] = f"{duration_ms:.2f}ms"
+    logger.info(f"⏱ {request.method} {request.url.path} → {duration_ms:.2f}ms")
+    return response


### PR DESCRIPTION
Every HTTP response now includes an X-Process-Time header with the request duration in milliseconds. Timing is recorded with time.perf_counter_ns() for accuracy and logged at INFO level.

Useful for observability via DevTools Network tab or structured logs.