### PR TITLE
fix: add ownership check to chunk preview endpoint

### DIFF
--- a/backend/app/routes/rag.py
+++ b/backend/app/routes/rag.py
@@ -340,6 +340,7 @@ async def get_chunk_preview(
     chunk_index: int = Query(..., ge=0, description="Target chunk index"),
     window: int = Query(default=2, ge=0, le=5, description="Neighbors on each side"),
     current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
 ):
     """
     Fetch a chunk and its neighbors for the preview panel.
@@ -347,8 +348,14 @@ async def get_chunk_preview(
     Returns the target chunk plus `window` chunks before and after it,
     ordered by chunk_index. The target chunk is flagged with is_target=True.
     """
+    document = db.query(RAGDocument).filter(RAGDocument.id == document_id).first()
+    if not document:
+        raise HTTPException(status_code=404, detail="Document not found")
+    if document.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Access denied")
+
     retriever = get_retriever()
-    result = retriever.retrieve_chunk_preview(document_id, chunk_index, window, current_user.id)
+    result = retriever.retrieve_chunk_preview(document_id, chunk_index, window)
 
     if not result:
         raise HTTPException(status_code=404, detail="Chunk not found")

--- a/backend/app/services/rag/retriever.py
+++ b/backend/app/services/rag/retriever.py
@@ -269,7 +269,7 @@ class Retriever:
         return formatted
 
     def retrieve_chunk_preview(
-        self, document_id: int, chunk_index: int, user_id: int, window: int = 2
+        self, document_id: int, chunk_index: int, window: int = 2
     ) -> Optional[Dict]:
         """
         Fetch a target chunk and its neighbors for the preview panel.
@@ -298,16 +298,6 @@ class Retriever:
                         FieldCondition(key="document_id", match=MatchValue(value=document_id)),
                         FieldCondition(key="chunk_index", range=Range(gte=min_idx, lte=max_idx)),
                     ],
-                    # should=[
-                    #    FieldCondition(
-                    #        key="user_id",
-                    #        match=MatchValue(value=user_id)
-                    #    ),
-                    #    FieldCondition(
-                    #        key="is_public",
-                    #        match=MatchValue(value=True)
-                    #    ),
-                    # ]
                 ),
                 limit=window * 2 + 1,
                 with_payload=True,
@@ -347,7 +337,7 @@ class Retriever:
             raise
 
     async def aretrieve_chunk_preview(
-        self, document_id: int, chunk_index: int, user_id: int, window: int = 2
+        self, document_id: int, chunk_index: int, window: int = 2
     ) -> Optional[Dict]:
         """Async version of retrieve_chunk_preview(). Uses AsyncQdrantClient."""
         from qdrant_client.models import Range


### PR DESCRIPTION
- Query DB to verify document exists and belongs to current user
- Raise 403 if document belongs to another user
- Remove user_id from retrieve_chunk_preview signature — ownership check belongs at the route layer, not inside the retriever
- Fix positional arg bug in route call (window/user_id were swapped)

Closes #24