### PR TITLE
Feat/issue 31 wire async retriever

### DIFF
--- a/backend/app/routes/rag.py
+++ b/backend/app/routes/rag.py
@@ -249,7 +249,7 @@ async def search_documents(
 ):
     retriever = get_retriever()
 
-    results = retriever.retrieve(
+    results = await retriever.aretrieve(
         query=q,
         user_id=current_user.id,
         top_k=top_k or settings.SEARCH_TOP_K,
@@ -291,7 +291,7 @@ async def get_chunk_preview(
         raise HTTPException(status_code=403, detail="Access denied")
 
     retriever = get_retriever()
-    result = retriever.retrieve_chunk_preview(document_id, chunk_index, window)
+    result = await retriever.aretrieve_chunk_preview(document_id, chunk_index, window)
 
     if not result:
         raise HTTPException(status_code=404, detail="Chunk not found")

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -212,7 +212,7 @@ async def process_chat_message_stream(
 
     if use_rag:
         try:
-            rag_context = rag_service.get_context(
+            rag_context = await rag_service.aget_context(
                 query=user_message, user_id=user_id, conversation_context=recent_rag_active
             )
             if rag_context:

--- a/backend/app/services/rag_service.py
+++ b/backend/app/services/rag_service.py
@@ -389,6 +389,65 @@ class RAGService:
             # Fail gracefully - chat continues without RAG
             return None
 
+    async def aget_context(
+        self, query: str, user_id: int, conversation_context: Optional[bool] = None
+    ) -> Optional[Dict]:
+        """Async version of get_context(). Uses AsyncQdrantClient via aretrieve()."""
+        try:
+            if not self.is_programming_question(query):
+                if not conversation_context:
+                    logger.info("⏭️  Skipping RAG (not programming-related)")
+                    return None
+                logger.info(
+                    "🔄 Follow-up detected — attempting retrieval despite no programming keywords"
+                )
+
+            topic = self.detect_topic(query)
+
+            logger.info(f"🔍 [async] Retrieving context for user {user_id}...")
+            results = await self.retriever.aretrieve(
+                query=query,
+                user_id=user_id,
+                topic=topic,
+                top_k=settings.RAG_TOP_K,
+                score_threshold=settings.RAG_SCORE_THRESHOLD,
+            )
+
+            if not results:
+                logger.info("ℹ️  No relevant context found")
+                return None
+
+            context_text = self._format_context(results)
+
+            logger.info(
+                f"✅ Retrieved {len(results)} chunks from "
+                f"{len(set(r['document_id'] for r in results))} documents"
+            )
+
+            return {
+                "context": context_text,
+                "chunks_count": len(results),
+                "detected_topic": topic,
+                "sources": [
+                    {
+                        "title": r["title"],
+                        "document_id": r["document_id"],
+                        "score": r["score"],
+                        "page_numbers": r.get("page_numbers", []),
+                        "chunk_type": r.get("chunk_type", "prose"),
+                        "chunk_index": r.get("chunk_index", None),
+                    }
+                    for r in results
+                ],
+            }
+
+        except Exception as e:
+            logger.error(f"❌ Error getting async context: {e}")
+            import traceback
+
+            traceback.print_exc()
+            return None
+
     def _format_context(self, results: List[Dict]) -> str:
         """
         Format retrieved chunks into context for LLM.


### PR DESCRIPTION
Wires the async Qdrant retriever into the RAG service and routes. Adds `aget_context()` to `RAGService` calling `await retriever.aretrieve()`, swaps both chat functions to `await rag_service.aget_context()`, and updates `search_documents` and `get_chunk_preview` in `rag.py` to use `aretrieve` and `aretrieve_chunk_preview`. The event loop is no longer blocked on Qdrant I/O during chat or search requests. Closes #31